### PR TITLE
Fix empty filtered clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Initial release of Joon-Klaps/viralgenie, created with the [nf-core](https://nf-
 
 - OOM with longer contigs for lowcov_to_reference, uses more RAM now ([#125](https://github.com/Joon-Klaps/viralgenie/pull/125))
 - fixing null output from global prefix ([#147](https://github.com/Joon-Klaps/viralgenie/pull/147))
+- Fix empty filtered clusters ([#148](https://github.com/Joon-Klaps/viralgenie/pull/148))
 
 ### `Parameters`
 - New parameter mmseqs_cluster_mode default to 0 ([#130](https://github.com/Joon-Klaps/viralgenie/pull/130))

--- a/assets/schemas/mapping_constrains.json
+++ b/assets/schemas/mapping_constrains.json
@@ -55,5 +55,5 @@
             "segment": ["species"]
         }
     },
-    "allOf": [{ "uniqueEntries": ["species", "segment"] }, { "uniqueEntries": ["id"] }]
+    "allOf": [{ "uniqueEntries": ["id","species", "segment"] }, { "uniqueEntries": ["id"] }]
 }

--- a/bin/extract_clust.py
+++ b/bin/extract_clust.py
@@ -388,7 +388,7 @@ def filter_members(clusters, pattern):
 
 def filter_clusters_by_coverage(clusters: list , coverages: dict, threshold: float) -> list:
     """
-    Filter clusters on coverage, only keep clusters with a coverage above the threshold.
+    Filter clusters on coverage, only keep clusters with a coverage above the threshold. If no clusters are kept, return top 5.
     """
     filtered_clusters = []
     for cluster in clusters:
@@ -397,7 +397,14 @@ def filter_clusters_by_coverage(clusters: list , coverages: dict, threshold: flo
         if any(cluster.cumulative_read_depth >= threshold):
             filtered_clusters.append(cluster)
 
-    return clusters,filtered_clusters
+    if filtered_clusters:
+        return clusters,filtered_clusters
+
+    sorted_clusters = sorted(clusters, key=lambda x: sum(x.cumulative_read_depth), reverse= True)
+    return sorted_clusters, sorted_clusters[:5]
+
+
+
 
 def parse_args(argv=None):
     """Define and immediately parse command line arguments."""

--- a/bin/extract_clust.py
+++ b/bin/extract_clust.py
@@ -386,7 +386,7 @@ def filter_members(clusters, pattern):
             filtered_clusters.append(cluster)
     return filtered_clusters
 
-def filter_clusters_by_coverage(clusters: list , coverages: dict, threshold: float) -> list:
+def filter_clusters_by_coverage(clusters: list , coverages: dict, threshold: float, keep_n_clusters: int) -> list:
     """
     Filter clusters on coverage, only keep clusters with a coverage above the threshold. If no clusters are kept, return top 5.
     """
@@ -401,7 +401,7 @@ def filter_clusters_by_coverage(clusters: list , coverages: dict, threshold: flo
         return clusters,filtered_clusters
 
     sorted_clusters = sorted(clusters, key=lambda x: sum(x.cumulative_read_depth), reverse= True)
-    return sorted_clusters, sorted_clusters[:5]
+    return sorted_clusters, sorted_clusters[:keep_n_clusters]
 
 
 
@@ -468,6 +468,16 @@ def parse_args(argv=None):
         help="Regex pattern to filter clusters by centroid sequence name.",
         default="^(TRINITY)|(NODE)|(k\d+)|(scaffold\d+)",  # Default pattern matches Trinity, SPADes, MEGAHIT, sspace_basic assembly names
     )
+
+    parser.add_argument(
+        "-n",
+        "--keep-clusters",
+        metavar="KEEP_CLUSTERS",
+        type=int,
+        help="Define the number of clusters to keep based if no clusters have at least the threshold value's read depth.",
+        default=5,
+    )
+
     parser.add_argument(
         "-l",
         "--log-level",
@@ -525,7 +535,7 @@ def main(argv=None):
     # Filter clusters by coverage
     if args.coverages:
         coverages = read_coverages(args.coverages)
-        clusters,filtered_clusters = filter_clusters_by_coverage(filtered_clusters, coverages, args.perc_reads_contig)
+        clusters,filtered_clusters = filter_clusters_by_coverage(filtered_clusters, coverages, args.perc_reads_contig, args.keep_clusters)
         logger.info("Filtered clusters by coverage, %d were removed.", len(clusters_renamed) - len(filtered_clusters))
 
     # Write the clusters to files


### PR DESCRIPTION
<!--
# nf-core/viralgenie pull request

Many thanks for contributing to nf-core/viralgenie!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/viralgenie/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist
Clusters with cumulative read depth of less then 5 causes the python script filter clusters to crash. Adding a variable to change this effect.

-   [ ] This comment contains a description of changes (with reason).
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/viralgenie/tree/master/.github/CONTRIBUTING.md)
-   [ ] If necessary, also make a PR on the nf-core/viralgenie _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
-   [ ] Make sure your code lints (`nf-core lint`).
-   [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
-   [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
-   [ ] Usage Documentation in `docs/usage.md` is updated.
-   [ ] Output Documentation in `docs/output.md` is updated.
-   [ ] `CHANGELOG.md` is updated.
-   [ ] `README.md` is updated (including new tool citations and authors/contributors).
